### PR TITLE
Update license and contributing information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# DEV
+# Contributing
 
 ## Prerequisites
 
@@ -27,4 +27,3 @@ invoke --list
 The release process is completly automated in Github Action.
 
 Just create a new GitHub release with the UI associated to a tag `vX.Y.Z` (don't miss the leading (lowercase) `v`).
-

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2023 Fabien MARTY
+Copyright (c) 2023 Botify and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ print(fnv_c.fnv1a_64(b"foo bar"))
 
 Full API doc is available at: [https://botify-labs.github.io/fnv-c/fnv_c/](https://botify-labs.github.io/fnv-c/fnv_c/)
 
-## Dev
+## Contributing
 
-See [this specific document](DEV.md)
+See [CONTRIBUTING](./CONTRIBUTING.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ Full API doc is available at: [https://botify-labs.github.io/fnv-c/fnv_c/](https
 ## Dev
 
 See [this specific document](DEV.md)
+
+## License
+
+**fnv-c** is licensed under the [MIT license](./LICENSE).


### PR DESCRIPTION
### Changed
- License: identify the project as being authored by Botify and contributors
- Contributing: rename from DEV.md so it will be shown on Github

### Notes
- I left the `setup.py` author information as-is, as I'm not sure we have an email alias for OSS contributions and feedback

### Reference
- https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors#adding-a-contributing-file