### PR TITLE
Complete wheel platform coverage (Linux aarch64 + Windows)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,8 +76,9 @@ jobs:
     strategy:
       matrix:
         # ubuntu-latest = x86_64, ubuntu-24.04-arm = native aarch64 (no QEMU),
-        # macos-latest builds both arm64 + x86_64 (see [tool.cibuildwheel.macos]).
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        # macos-latest builds both arm64 + x86_64 (see [tool.cibuildwheel.macos]),
+        # windows-latest = win_amd64.
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # ubuntu-latest = x86_64, ubuntu-24.04-arm = native aarch64 (no QEMU),
+        # macos-latest builds both arm64 + x86_64 (see [tool.cibuildwheel.macos]).
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
Follow-up to #11. We shipped x86_64 Linux + macOS (arm64/x86_64), but two obvious platforms were missing: **Linux aarch64** and **Windows**. This fills both gaps.

- **Linux aarch64** — adds `ubuntu-24.04-arm`, GitHub's native arm64 runner, so cibuildwheel (`auto64`) builds `manylinux_aarch64` + `musllinux_aarch64` with **no QEMU**. (AWS Graviton, Ampere, arm64 containers.)
- **Windows** — adds `windows-latest`, producing `win_amd64` wheels so Windows users don't need MSVC Build Tools to compile the sdist.

## Wheel coverage after this

| Platform | Arch | Pythons |
|---|---|---|
| manylinux + musllinux | x86_64 | cp310–cp314, pp311¹ |
| manylinux + musllinux | aarch64 | cp310–cp314, pp311¹ |
| macOS | arm64 + x86_64 | cp310–cp314, pp311 |
| Windows | win_amd64 | cp310–cp314, pp311 |

¹ PyPy is manylinux-only (no musllinux PyPy exists).

No `[tool.cibuildwheel.windows]` config needed — `auto` on the AMD64 runner yields win_amd64 only (no win32/arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)